### PR TITLE
Copy necessary cfg files to the target dir

### DIFF
--- a/cppcheck.lua
+++ b/cppcheck.lua
@@ -30,7 +30,7 @@ project "cppcheck"
     "externals/tinyxml/*.cpp",
   }
 
-  local target_dir_platform=""
+  local target_dir=""
 
   -- -------------------------------------------------------------
   -- configurations
@@ -47,13 +47,22 @@ project "cppcheck"
 
     -- project specific configuration settings
 
+    target_dir=_TOOLS_DIR .. "/cppcheck/bin/win"
+
     configuration { "windows" }
 
       links {
         "Shlwapi",
       }
 
-    target_dir_platform="win"
+      -- Copy the necessary cfg files that cppcheck requires to load at runtime
+      -- For Windows, we need to use copy which expects windows style path seperators
+      local source_path=path.translate(prjDir .. "/cfg/")
+      local destination_path=path.translate(target_dir)
+      postbuildcommands {
+        "copy " .. source_path .. "std.cfg " .. destination_path,
+        "copy " .. source_path .. "windows.cfg " .. destination_path,
+      }
 
     -- -------------------------------------------------------------
     -- configuration { "windows", "Debug", "x32" }
@@ -117,9 +126,14 @@ project "cppcheck"
 
     -- project specific configuration settings
 
-    -- configuration { "linux" }
+    target_dir=_TOOLS_DIR .. "/cppcheck/bin/linux"
 
-    target_dir_platform="linux"
+    configuration { "linux" }
+
+      -- Copy the necessary cfg files that cppcheck requires to load at runtime
+      postbuildcommands {
+        "cp cfg/std.cfg " .. target_dir,
+      }
 
     -- -------------------------------------------------------------
     -- configuration { "linux", "Debug", "x64" }
@@ -159,9 +173,14 @@ project "cppcheck"
 
     -- project specific configuration settings
 
-    -- configuration { "macosx" }
+    target_dir=_TOOLS_DIR .. "/cppcheck/bin/macos"
 
-    target_dir_platform="macos"
+    configuration { "macosx" }
+
+      -- Copy the necessary cfg files that cppcheck requires to load at runtime
+      postbuildcommands {
+        "cp cfg/std.cfg " .. target_dir,
+      }
 
     -- -------------------------------------------------------------
     -- configuration { "macosx", "Debug", "x64" }
@@ -200,4 +219,4 @@ project "cppcheck"
     targetsuffix ""
 
     -- Override the targetdir to the tools/cppcheck/bin/${os} directory
-    targetdir(_TOOLS_DIR .. "/cppcheck/bin/" .. target_dir_platform)
+    targetdir(target_dir)


### PR DESCRIPTION
cppcheck requires a few cfg txt files to properly run. Add
it to the target dir as a postbuild command.

@dkalowsk when actually running the binaries against code, I remembered that cppcheck requires cfg files to properly work.

vTest: http://runtime-test.esri.com:8080/view/DEV/job/dev-vtest-3rdparty_tools-interface/16/downstreambuildview/
Issue-number: https://devtopia.esri.com/runtimecore/architecture/issues/742