### PR TITLE
premake: Use _PLATFORM booleans to clean up platform checks

### DIFF
--- a/cppcheck.lua
+++ b/cppcheck.lua
@@ -37,7 +37,7 @@ project "cppcheck"
   -- configurations
   -- -------------------------------------------------------------
 
-  if (os.is("windows") and not _TARGET_IS_WINUWP) then
+  if (_PLATFORM_WINDOWS) then
     -- -------------------------------------------------------------
     -- configuration { "windows" }
     -- -------------------------------------------------------------
@@ -114,7 +114,7 @@ project "cppcheck"
     -- -------------------------------------------------------------
   end
 
-  if (os.is("linux") and not _OS_IS_ANDROID) then
+  if (_PLATFORM_LINUX) then
     -- -------------------------------------------------------------
     -- configuration { "linux" }
     -- -------------------------------------------------------------
@@ -159,7 +159,7 @@ project "cppcheck"
     -- -------------------------------------------------------------
   end
 
-  if (os.is("macosx") and not _OS_IS_IOS and not _OS_IS_ANDROID) then
+  if (_PLATFORM_MACOS) then
     -- -------------------------------------------------------------
     -- configuration { "macosx" }
     -- -------------------------------------------------------------
@@ -209,7 +209,7 @@ project "cppcheck"
   -- -------------------------------------------------------------
 
   configuration { "*" }
-  
+
     -- Remove the 'd' from debug builds
     targetsuffix ""
 


### PR DESCRIPTION
Issue-number: https://devtopia.esri.com/runtime/devops/issues/579