### PR TITLE
arch: Make changes needed for the new premake build structure

### DIFF
--- a/cppcheck.lua
+++ b/cppcheck.lua
@@ -1,217 +1,54 @@
 project "cppcheck"
 
-  local prj = project()
-  local prjDir = prj.basedir
+dofile(_BUILD_DIR .. "/console_application.lua")
 
-  -- -------------------------------------------------------------
-  -- project
-  -- -------------------------------------------------------------
+configuration { "*" }
 
-  -- common project settings
+uuid "810F8D2E-8D3F-4A9D-ADC5-308233BBC3EE"
 
-  dofile (_BUILD_DIR .. "/3rdparty_shared_project.lua")
+includedirs {
+  "externals",
+  "externals/simplecpp",
+  "externals/tinyxml",
+  "lib",
+}
 
-  -- project specific settings
+files {
+  "cli/*.cpp",
+  "lib/*.cpp",
+  "externals/simplecpp/simplecpp.cpp",
+  "externals/tinyxml/*.cpp",
+}
 
-  kind "ConsoleApp"
+-- Override the targetdir to the runtime/tools/cppcheck/bin directory
+target_dir=_TOOLS_DIR .. "/cppcheck/bin"
+targetdir(target_dir)
 
-  uuid "810F8D2E-8D3F-4A9D-ADC5-308233BBC3EE"
+if (_PLATFORM_LINUX) then
+  -- Copy the necessary cfg files that cppcheck requires to load at runtime
+  postbuildcommands {
+    "cp cfg/std.cfg " .. target_dir,
+  }
+end
 
-  includedirs {
-    "externals",
-    "externals/simplecpp",
-    "externals/tinyxml",
-    "lib",
+if (_PLATFORM_MACOS) then
+  -- Copy the necessary cfg files that cppcheck requires to load at runtime
+  postbuildcommands {
+    "cp cfg/std.cfg " .. target_dir,
+  }
+end
+
+if (_PLATFORM_WINDOWS) then
+  links {
+    "Shlwapi",
   }
 
-  files {
-    "cli/*.cpp",
-    "lib/*.cpp",
-    "externals/simplecpp/simplecpp.cpp",
-    "externals/tinyxml/*.cpp",
+  -- Copy the necessary cfg files that cppcheck requires to load at runtime
+  -- For Windows, we need to use copy which expects windows style path seperators
+  local source_path=path.translate("cfg/")
+  local destination_path=path.translate(target_dir)
+  postbuildcommands {
+    "copy " .. source_path .. "std.cfg " .. destination_path,
+    "copy " .. source_path .. "windows.cfg " .. destination_path,
   }
-
-  target_dir=_TOOLS_DIR .. "/cppcheck/bin"
-
-  -- -------------------------------------------------------------
-  -- configurations
-  -- -------------------------------------------------------------
-
-  if (_PLATFORM_WINDOWS) then
-    -- -------------------------------------------------------------
-    -- configuration { "windows" }
-    -- -------------------------------------------------------------
-
-    -- common configuration settings
-
-    dofile (_BUILD_DIR .. "/shared_win.lua")
-
-    -- project specific configuration settings
-
-    configuration { "windows" }
-
-      links {
-        "Shlwapi",
-      }
-
-      -- Copy the necessary cfg files that cppcheck requires to load at runtime
-      -- For Windows, we need to use copy which expects windows style path seperators
-      local source_path=path.translate(prjDir .. "/cfg/")
-      local destination_path=path.translate(target_dir)
-      postbuildcommands {
-        "copy " .. source_path .. "std.cfg " .. destination_path,
-        "copy " .. source_path .. "windows.cfg " .. destination_path,
-      }
-
-    -- -------------------------------------------------------------
-    -- configuration { "windows", "Debug", "x32" }
-    -- -------------------------------------------------------------
-
-    -- common configuration settings
-
-    dofile (_BUILD_DIR .. "/shared_win_x86_debug.lua")
-
-    -- project specific configuration settings
-
-    -- configuration { "windows", "Debug", "x32" }
-
-    -- -------------------------------------------------------------
-    -- configuration { "windows", "Debug", "x64" }
-    -- -------------------------------------------------------------
-
-    -- common configuration settings
-
-    dofile (_BUILD_DIR .. "/shared_win_x64_debug.lua")
-
-    -- project specific configuration settings
-
-    -- configuration { "windows", "Debug", "x64" }
-
-    -- -------------------------------------------------------------
-    -- configuration { "windows", "Release", "x32" }
-    -- -------------------------------------------------------------
-
-    -- common configuration settings
-
-    dofile (_BUILD_DIR .. "/shared_win_x86_release.lua")
-
-    -- project specific configuration settings
-
-    -- configuration { "windows", "Release", "x32" }
-
-    -- -------------------------------------------------------------
-    -- configuration { "windows", "Release", "x64" }
-    -- -------------------------------------------------------------
-
-    -- common configuration settings
-
-    dofile (_BUILD_DIR .. "/shared_win_x64_release.lua")
-
-    -- project specific configuration settings
-
-    -- configuration { "windows", "Release", "x64" }
-
-    -- -------------------------------------------------------------
-  end
-
-  if (_PLATFORM_LINUX) then
-    -- -------------------------------------------------------------
-    -- configuration { "linux" }
-    -- -------------------------------------------------------------
-
-    -- common configuration settings
-
-    dofile (_BUILD_DIR .. "/shared_linux.lua")
-
-    -- project specific configuration settings
-
-    configuration { "linux" }
-
-      -- Copy the necessary cfg files that cppcheck requires to load at runtime
-      postbuildcommands {
-        "cp cfg/std.cfg " .. target_dir,
-      }
-
-    -- -------------------------------------------------------------
-    -- configuration { "linux", "Debug", "x64" }
-    -- -------------------------------------------------------------
-
-    -- common configuration settings
-
-    dofile (_BUILD_DIR .. "/shared_linux_x64_debug.lua")
-
-    -- project specific configuration settings
-
-    -- configuration { "linux", "Debug", "x64" }
-
-    -- -------------------------------------------------------------
-    -- configuration { "linux", "Release", "x64" }
-    -- -------------------------------------------------------------
-
-    -- common configuration settings
-
-    dofile (_BUILD_DIR .. "/shared_linux_x64_release.lua")
-
-    -- project specific configuration settings
-
-    -- configuration { "linux", "Release", "x64" }
-
-    -- -------------------------------------------------------------
-  end
-
-  if (_PLATFORM_MACOS) then
-    -- -------------------------------------------------------------
-    -- configuration { "macosx" }
-    -- -------------------------------------------------------------
-
-    -- common configuration settings
-
-    dofile (_BUILD_DIR .. "/shared_mac.lua")
-
-    -- project specific configuration settings
-
-    configuration { "macosx" }
-
-      -- Copy the necessary cfg files that cppcheck requires to load at runtime
-      postbuildcommands {
-        "cp cfg/std.cfg " .. target_dir,
-      }
-
-    -- -------------------------------------------------------------
-    -- configuration { "macosx", "Debug", "x64" }
-    -- -------------------------------------------------------------
-
-    -- common configuration settings
-
-    dofile (_BUILD_DIR .. "/shared_mac_x64_debug.lua")
-
-    -- project specific configuration settings
-
-    -- configuration { "macosx", "Debug", "x64" }
-
-    -- -------------------------------------------------------------
-    -- configuration { "macosx", "Release", "x64" }
-    -- -------------------------------------------------------------
-
-    -- common configuration settings
-
-    dofile (_BUILD_DIR .. "/shared_mac_x64_release.lua")
-
-    -- project specific configuration settings
-
-    -- configuration { "macosx", "Release", "x64" }
-
-    -- -------------------------------------------------------------
-  end
-
-  -- -------------------------------------------------------------
-  -- configuration { "*" }
-  -- -------------------------------------------------------------
-
-  configuration { "*" }
-
-    -- Remove the 'd' from debug builds
-    targetsuffix ""
-
-    -- Override the targetdir to the runtime/tools/cppcheck/bin directory
-    targetdir(target_dir)
+end


### PR DESCRIPTION
The premake build structure has been simplified and rewritten to reduce
the boilerplate needed to add additional configurations while forcing
the unique settings of a project to be defined. Migrate some defines
and compiler options to the global settings and remove all the old
boilerplate from this project.

Issue-number: https://devtopia.esri.com/runtime/devops/issues/830